### PR TITLE
STRIPES-834 Update stripes-core, bump to v2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Change history for stripes-ui
 
-## 2.0.0 IN PROGRESS
-* Update `stripes-core` to `v9`.
-
-## [1.0.0](https://github.com/folio-org/stripes-ui/tree/v1.0.0) (2023-01-20)
+## 1.0.0 IN PROGRESS
 
 * Initial setup
+* Update `stripes-core` to `v9`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change history for stripes-ui
 
-## 1.0.0 IN PROGRESS
+## 2.0.0 IN PROGRESS
+* Update `stripes-core` to `v9`.
+
+## [1.0.0](https://github.com/folio-org/stripes-ui/tree/v1.0.0) (2023-01-20)
 
 * Initial setup

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-ui",
-  "version": "2.0.0",
+  "version": "1.0.0",
   "description": "The main UI wrapper responsible for setting the global layout, navigation menu and top bar",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-ui",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@folio/stripes-ui",
-  "version": "1.0.0",
+  "version": "2.0.0",
   "description": "The main UI wrapper responsible for setting the global layout, navigation menu and top bar",
   "license": "Apache-2.0",
   "repository": "folio-org/stripes-ui",
@@ -21,9 +21,8 @@
     "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/stripes-ui ./translations/stripes-ui/compiled"
   },
   "peerDependencies": {
-    "@folio/stripes-core": "^8.2.0"
+    "@folio/stripes-core": "^9.0.0"
   },
-
   "devDependencies": {
     "@formatjs/cli": "^4.2.2",
     "jest": "^28.0.1",


### PR DESCRIPTION
- Bumping `stripes-core` version to `v9`.
- Part of https://issues.folio.org/browse/STRIPES-834