### PR TITLE
STRIPESUI-6 BREAKING bump `@folio/stripes-core` to v10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 2.0.0 IN PROGRESS
 
+* *BREAKING* Bump `@folio/stripes-core` to `v10` (bump `react` to `v18`). Refs STRIPESUI-6.
+
 ## [1.0.0](https://github.com/folio-org/stripes-ui/tree/v1.0.0) (2023-01-30)
 
 * Initial release

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/stripes-ui ./translations/stripes-ui/compiled"
   },
   "peerDependencies": {
-    "@folio/stripes-core": "^9.1.0"
+    "@folio/stripes-core": "^10.0.0"
   },
   "devDependencies": {
     "@formatjs/cli": "^4.2.2",


### PR DESCRIPTION
Bump `@folio/stripes-core` to `v10`, corresponding to bumping `react` to `v18`.

Refs [STRIPESUI-6](https://issues.folio.org/browse/STRIPESUI-6)