### PR TITLE
STRIPESUI-15 eliminate unused translation deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,12 @@
     "test:jest": "jest --ci --coverage --colors --passWithNoTests",
     "lint": "eslint . && stylelint \"src/**/*.css\"",
     "eslint": "eslint .",
-    "stylelint": "stylelint \"src/**/*.css\"",
-    "formatjs-compile": "formatjs compile-folder --ast --format simple ./translations/stripes-ui ./translations/stripes-ui/compiled"
+    "stylelint": "stylelint \"src/**/*.css\""
   },
   "peerDependencies": {
     "@folio/stripes-core": "^11.0.0"
   },
   "devDependencies": {
-    "@formatjs/cli": "^6.1.3",
     "jest": "^28.0.1",
     "jest-canvas-mock": "^2.3.1",
     "jest-environment-jsdom": "^28.1.3",


### PR DESCRIPTION
There are no translations here, hence no need for a compile-translations script or dependency.

Refs [STRIPESUI-15](https://folio-org.atlassian.net/browse/STRIPESUI-15)